### PR TITLE
Add early return convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@
 
 ## 컨벤션
 
+### Early returns
+- 예측가능하고 제어가 가능한 예외사항은 `throw` 대신에 `early return`을 사용한다.
+- 최대한 `else`의 사용을 피한다.
+
+```php
+if (! $CONDITION) {
+    return;
+}
+```
+
 ### Json Response
 - json response는 `response()->json()` 형태를 사용합니다.
 - status code는 직관성을 위해 위해 `JsonResponse`를 사용합니다.

--- a/README.md
+++ b/README.md
@@ -20,12 +20,7 @@
 ### Early returns
 - 예측가능하고 제어가 가능한 예외사항은 `throw` 대신에 `early return`을 사용한다.
 - 최대한 `else`의 사용을 피한다.
-
-```php
-if (! $CONDITION) {
-    return;
-}
-```
+- 가급적 `if` 조건에는 부정 (`!`) 연산자를 사용하지 않는다.
 
 ### Json Response
 - json response는 `response()->json()` 형태를 사용합니다.


### PR DESCRIPTION
예외사항에서 throw의 사용을 지양하고,
else의 사용을 피하는 부분에 대해서 기술하였습니다.

else를 피하는 부분은 spatie의 가이드라인을 참고하였습니다.
https://github.com/spatie/guidelines.spatie.be/blob/master/content/code-style/laravel-php.md#avoid-else